### PR TITLE
Error location

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,15 @@ main = do
         else putStrLn "Not all tests passed"
 ```
 
+Source location can be added to assertions to improve error messages.
+
+```idris
+withSource = test "location" $ do
+    assert
+        {loc = here `(())}
+        False
+```
+
 ## License
 
 All code is licensed under the [MPL-2.0](LICENSES/MPL-2.0.txt).

--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ main = do
 Source location can be added to assertions to improve error messages.
 
 ```idris
+import Language.Reflection
+%language ElabReflection
+
 withSource = test "location" $ do
     assert
         {loc = here `(())}

--- a/src/Tester.idr
+++ b/src/Tester.idr
@@ -54,7 +54,7 @@ emptyLoc = Loc EmptyFC
 ||| This can be passed to assertion to attach source location
 |||
 ||| ```idris example
-||| let loc = loc `(())
+||| let loc = here `(())
 |||  in assertEq {loc} 
 export %macro
 here : TTImp -> Elab Location


### PR DESCRIPTION
This is completely backwards compatible

I have made `Location` a newtype to reduce number of needed dependencies when not using this feature